### PR TITLE
Add InnoDB buffer pool size/instances

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update && apt-get install wget -y && \
 ADD ./conf/mysql_server.cnf /mysql_server.cnf
 ADD ./run.sh /run.sh
 
+ENV MARIADB_INNODB_BUFFER_POOL_SIZE=134217728 \
+  MARIADB_INNODB_BUFFER_POOL_INSTANCES=1
+
 # Exposed galera cluster ports + MariaDB port
 EXPOSE 4567 4568 4444 3306
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ docker run -it -e MYSQL_ALLOW_EMPTY_PASSWORD=true --name=mariadb-2 -e HOSTNAME=m
 | MYSQL_USER | `username` | An user name to create on first launch. Must provide `MYSQL_PASSWORD` env var. If `MYSQL_DATABASE` is provided, it will be granted access to it |
 | MARIADB_DEFAULT_STORAGE_ENGINE | `InnoDB` | The default storage engine to use for the node |
 | GALERA_SLAVE_THREADS | `1` | Number of slave threads to start, [see doc](https://mariadb.com/kb/en/mariadb/galera-cluster-system-variables/#wsrep_slave_threads) |
+| MARIADB_INNODB_BUFFER_POOL_SIZE | `134217728` | The pool size of your InnoDB buffers (in bytes), [see doc](https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_buffer_pool_size) |
+| MARIADB_INNODB_BUFFER_POOL_INSTANCES | `1` | The number of instances for your InnoDB buffers, [see doc](https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_buffer_pool_instances). Each should be at least 1GB of size (`POOL_SIZE`) |
 
 # Things to know
 ## Cluster shut down and clustering recovery

--- a/conf/mysql_server.cnf
+++ b/conf/mysql_server.cnf
@@ -8,6 +8,8 @@ binlog_format=row
 default_storage_engine={{ .Env.MARIADB_DEFAULT_STORAGE_ENGINE }}
 innodb_autoinc_lock_mode=2
 innodb_locks_unsafe_for_binlog=1
+innodb_buffer_pool_size={{ .Env.MARIADB_INNODB_BUFFER_POOL_SIZE }}
+innodb_buffer_pool_instances={{ .Env.MARIADB_INNODB_BUFFER_POOL_INSTANCES }}
 query_cache_size=0
 query_cache_type=0
 


### PR DESCRIPTION
Add two new parameters, useful for large deployments and production usage of MariaDB:


| Name          | Example       | Description  |
| ------------- |:-------------:|--------------|
| MARIADB_INNODB_BUFFER_POOL_SIZE | `134217728` | The pool size of your InnoDB buffers (in bytes), [see doc](https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_buffer_pool_size) |
| MARIADB_INNODB_BUFFER_POOL_INSTANCES | `1` | The number of instances for your InnoDB buffers, [see doc](https://mariadb.com/kb/en/mariadb/xtradbinnodb-server-system-variables/#innodb_buffer_pool_instances). Each should be at least 1GB of size (`POOL_SIZE`) |